### PR TITLE
Add ability to call Raygun directly

### DIFF
--- a/Lib/RaygunError.php
+++ b/Lib/RaygunError.php
@@ -10,39 +10,40 @@
 App::import('Vendor', 'Raygun4php', array('file' => 'Raygun4php' . DS . 'RaygunClient.php'));
 
 class RaygunError extends ErrorHandler {
+	public static $useAsyncSending = true;
 
-	// Overload Errors:
-	public static function handleError($code, $description, $file = null, $line = null, $context = null) {
+	public static $debugMode = false;
 
-		// Raygun settings
-		$useAsyncSending = true;
-		$debugMode = false;
-
+	// Call Raygun without calling handleError()
+	public static function handleErrorRaygun($code, $description, $file = null, $line = null) {
 		// Call Raygun
-		$apiKey  = Configure::read('RaygunCake.apiKey'); // This is required
-		$client = new \Raygun4php\RaygunClient($apiKey, $useAsyncSending, $debugMode);
+		$apiKey = Configure::read('RaygunCake.apiKey'); // This is required
+		$client = new \Raygun4php\RaygunClient($apiKey, self::$useAsyncSending, self::$debugMode);
 		$client->SendError($code, $description, $file, $line);
+	}
+
+	// Call Raygun without calling handleException
+	public static function handleExceptionRaygun(Exception $exception) {
+		// Call Raygun
+		$apiKey = Configure::read('RaygunCake.apiKey'); // This is required
+		$client = new \Raygun4php\RaygunClient($apiKey, self::$useAsyncSending, self::$debugMode);
+		$client->SendException($exception);
+	}
+
+	// Overload Errors: Call Raygun AND handleError()
+	public static function handleError($code, $description, $file = null, $line = null, $context = null) {
+		self::handleErrorRaygun($code, $description, $file, $line);
 
 		// Fall back to cake
 		return parent::handleError($code, $description, $file, $line, $context);
 	}
 
-	// Overload Exceptions:
+	// Overload Exceptions: Call Raygun AND handleException()
 	public static function handleException(Exception $exception) {
-
-		// Raygun settings
-		$useAsyncSending = true;
-		$debugMode = false;
-
-		// Call Raygun
-		$apiKey  = Configure::read('RaygunCake.apiKey'); // This is required
-		$client = new \Raygun4php\RaygunClient($apiKey, $useAsyncSending, $debugMode);
-		$client->SendException($exception);
+		self::handleExceptionRaygun($exception);
 
 		// Fall back to Cake..
 		return parent::handleException($exception);
 	}
-
-
 
 }


### PR DESCRIPTION
Two new public methods were added to allow Raygun to be called independently of Cake's error handling. Added class variables for debug and async settings.

The user now has the choice between calling RaygunError::handleErrorRaygun() to report an error directly to Raygun OR calling RaygunError::handleError() to trigger normal error handling in addition to notifying Raygun.

The ability to call Raygun without triggering further error handling within Cake is essential to using Raygun as a "messaging" system in which you want to alert or track certain things without necessarily treating them as application errors within Cake.

This change is completely backwards compatible.