### PR TITLE
Add ability to provide your app version to Raygun

### DIFF
--- a/Lib/RaygunError.php
+++ b/Lib/RaygunError.php
@@ -19,6 +19,9 @@ class RaygunError extends ErrorHandler {
 		// Call Raygun
 		$apiKey = Configure::read('RaygunCake.apiKey'); // This is required
 		$client = new \Raygun4php\RaygunClient($apiKey, self::$useAsyncSending, self::$debugMode);
+		if (Configure::read('RaygunCake.version')) {
+			$client->SetVersion(Configure::read('RaygunCake.version'));
+		}
 		$client->SendError($code, $description, $file, $line);
 	}
 
@@ -27,6 +30,9 @@ class RaygunError extends ErrorHandler {
 		// Call Raygun
 		$apiKey = Configure::read('RaygunCake.apiKey'); // This is required
 		$client = new \Raygun4php\RaygunClient($apiKey, self::$useAsyncSending, self::$debugMode);
+		if (Configure::read('RaygunCake.version')) {
+			$client->SetVersion(Configure::read('RaygunCake.version'));
+		}
 		$client->SendException($exception);
 	}
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ app/Config/bootstrap.php
 // Include our awesome error catcher..
 CakePlugin::load('RaygunCake');
 Configure::write('RaygunCake.apiKey', '<API KEY>');
+// Optional: Send your application's version number
+Configure::write('RaygunCake.version', '1.2.3.4');
 App::uses('RaygunError', 'RaygunCake.Lib');
 ```
 


### PR DESCRIPTION
Raygun version field can now be populated for errors by setting the desired value via:  Configure::write('RaygunCake.version', '1.2.3.4');

